### PR TITLE
Update keras-model-specs in entrypoint.sh to get latest specs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xe
 
-pip install --upgrade pip stored
+pip install --upgrade pip stored keras-model-specs
 stored sync $SERVING_MODEL /model/1
 
 cd /opt

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='model-serving',
-    version='0.0.2',
+    version='0.0.3',
     description='A tensorflow-serving model server via HTTP.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
If I try to spin up a densenet_121 now it will fail because the version of `keras-model-specs` in the Docker image doesn't have it yet.